### PR TITLE
修改README.md中 app.config.jwt.secret 为 app.config.secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ curl -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJi
 ## How To Create A Token
 
 ```
-const token = app.jwt.sign({ foo: 'bar' }, app.config.jwt.secret);
+const token = app.jwt.sign({ foo: 'bar' }, app.config.secret);
 ```
 
 ## Questions & Suggestions


### PR DESCRIPTION
配置时
<img width="452" alt="2017-05-05 2 59 46" src="https://cloud.githubusercontent.com/assets/1948312/25736389/1c0e2dbc-31a4-11e7-8ff0-b37e1eb59cdd.png">

调用时
<img width="629" alt="2017-05-05 3 00 01" src="https://cloud.githubusercontent.com/assets/1948312/25736396/23d1f808-31a4-11e7-9119-1851f17c93e8.png">

使用过程中，发现app.config.jwt.secret 调用的是默认值 'shared-key'


